### PR TITLE
Add -Dappengine.server property for custom appspot servers, i.e. not

### DIFF
--- a/gae-tools/src/main/java/org/jboss/arquillian/container/appengine/tools/AppEngineToolsConfiguration.java
+++ b/gae-tools/src/main/java/org/jboss/arquillian/container/appengine/tools/AppEngineToolsConfiguration.java
@@ -38,6 +38,11 @@ public class AppEngineToolsConfiguration extends AppEngineCommonConfiguration {
     private String userId = System.getProperty(PREFIX + "userId");
     private String password = System.getProperty(PREFIX + "password"); // TODO better?
 
+    // This server is the app under test.
+    // See AppEngineToolsContainer.java for the APPENGINE_SERVER environment setting used to
+    // upload the app.
+    private String server = System.getProperty(PREFIX + "server"); //
+
     public boolean isUpdateCheck() {
         return updateCheck;
     }
@@ -76,5 +81,13 @@ public class AppEngineToolsConfiguration extends AppEngineCommonConfiguration {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getServer() {
+        return server;
+    }
+
+    public void setServer(String server) {
+        this.server = server;
     }
 }

--- a/gae-tools/src/main/java/org/jboss/arquillian/container/appengine/tools/AppEngineToolsContainer.java
+++ b/gae-tools/src/main/java/org/jboss/arquillian/container/appengine/tools/AppEngineToolsContainer.java
@@ -123,7 +123,12 @@ public class AppEngineToolsContainer extends AppEngineCommonContainer<AppEngineT
 
             final String id = app.getVersion() + "." + app.getAppId();
 
-            return getProtocolMetaData(id + ".appspot.com", configuration.getPort(), archive);
+            String server = configuration.getServer();
+            if (server == null) {
+                server = "appspot.com";
+            }
+
+            return getProtocolMetaData(id + "." + server, configuration.getPort(), archive);
         } catch (DeploymentException e) {
             throw e;
         } catch (AppEngineConfigException e) {
@@ -170,6 +175,8 @@ public class AppEngineToolsContainer extends AppEngineCommonContainer<AppEngineT
          */
 
         final AppAdminFactory.ConnectOptions appEngineConnectOptions = new AppAdminFactory.ConnectOptions();
+        // APPENGINE_SERVER is server to upload the app.
+        //  The default is appspot.com, which is used for both upload and test container.
         String appengineServer = System.getenv("APPENGINE_SERVER");
         if (appengineServer != null) {
             appEngineConnectOptions.setServer(appengineServer);


### PR DESCRIPTION
appspot.com.  Set env APPENGINE_SERVER to the servername that will be
used to upload the app.  Use -Dappengine.server for the server that will
be running the app.  If you use appspot.com, that is the default for
both so you don't need to worry about setting this.
