### PR TITLE
Use version-dot-appid instead of version.appid in hostname

### DIFF
--- a/gae-tools/src/main/java/org/jboss/arquillian/container/appengine/tools/AppEngineToolsContainer.java
+++ b/gae-tools/src/main/java/org/jboss/arquillian/container/appengine/tools/AppEngineToolsContainer.java
@@ -127,7 +127,7 @@ public class AppEngineToolsContainer extends AppEngineCommonContainer<AppEngineT
                 throw new DeploymentException("Cannot deploy via GAE tools: " + status);
             }
 
-            final String id = app.getVersion() + "." + app.getAppId();
+            final String id = app.getVersion() + "-dot-" + app.getAppId();
 
             String server = configuration.getServer();
             if (server == null) {


### PR DESCRIPTION
For https access, the url's must use '-dot-' instead of '.' (see https://developers.google.com/appengine/kb/general#https )
